### PR TITLE
Update gallery layout and video alignment

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -88,10 +88,9 @@ ul {
 
 /* Image Grid */
 .photo-grid {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
   gap: 1rem;
-  justify-content: center;
   margin: 2rem 0;
 }
 
@@ -131,7 +130,7 @@ ul {
   padding-bottom: 56.25%; /* 16:9 ratio */
   height: 0;
   overflow: hidden;
-  margin: 3rem auto;
+  margin: 3rem 0;
   width: 100%;
   max-width: 1000px; /* or 1200px if you want bigger */
 }
@@ -200,22 +199,17 @@ ul {
   }
 
   .photo-grid {
-    justify-content: center;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
     gap: 0.75rem;
-  }
-
-  .photo-grid img {
-    width: 44vw;
-    max-width: 160px;
   }
 }
 
 .photo-card {
-  width: 200px;
+  width: 100%;
   position: relative;
   border-radius: 6px;
   overflow: hidden;
-  display: inline-block;
+  display: block;
 }
 
 .photo-card .photo-title {


### PR DESCRIPTION
## Summary
- use CSS grid for photo grids so 6 photos show as two rows of three
- have photo cards fill the grid width
- left align Vimeo videos with page titles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842e7e9ab948321a5a375d4118dd013