### PR TITLE
Fix spacing on video pages

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -77,6 +77,10 @@ h2 {
   margin-bottom: 2rem;
 }
 
+.video-title {
+  margin-bottom: 1rem;
+}
+
 section p, ul {
   margin-bottom: 2rem;
 }
@@ -130,7 +134,7 @@ ul {
   padding-bottom: 56.25%; /* 16:9 ratio */
   height: 0;
   overflow: hidden;
-  margin: 3rem 0;
+  margin: 1.5rem 0;
   width: 100%;
   max-width: 1000px; /* or 1200px if you want bigger */
 }

--- a/film1.html
+++ b/film1.html
@@ -20,7 +20,7 @@
 
   <main class="video-page">
     <section>
-      <h2>The Journey</h2>
+      <h2 class="video-title">The Journey</h2>
       <div class="video-wrapper">
         <iframe src="https://player.vimeo.com/video/123456789" frameborder="0" allowfullscreen></iframe>
       </div>

--- a/wedding1.html
+++ b/wedding1.html
@@ -20,7 +20,7 @@
 
   <main>
     <section>
-      <h2>Bryan and Emily</h2>
+      <h2 class="video-title">Bryan and Emily</h2>
       <div class="video-wrapper">
         <iframe src="https://player.vimeo.com/video/76979871" frameborder="0" allowfullscreen></iframe>
       </div>

--- a/wedding2.html
+++ b/wedding2.html
@@ -20,7 +20,7 @@
 
   <main>
     <section>
-      <h2>Lexi Jo & Landry</h2>
+      <h2 class="video-title">Lexi Jo & Landry</h2>
       <div class="video-wrapper">
         <iframe src="https://player.vimeo.com/video/76979871" frameborder="0" allowfullscreen></iframe>
       </div>


### PR DESCRIPTION
## Summary
- reduce default video wrapper margin
- add `.video-title` style
- mark headings on video pages with `.video-title`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842ea2cc6f08321a9cc36ce99711a49