### PR TITLE
Remove extra page spacing

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -14,7 +14,6 @@ body {
   line-height: 1.6;
   display: flex;
   flex-direction: column;
-  min-height: 100vh;
 }
 
 /* Sidebar Navigation */
@@ -70,7 +69,6 @@ nav a:hover::after {
 main {
   margin-left: 220px;
   padding: 4rem 2rem 2rem;
-  flex: 1;
 }
 footer {
   margin-left: 220px;


### PR DESCRIPTION
## Summary
- trim off unused `min-height` on the body
- let `<main>` size to its content instead of stretching

## Testing
- `grep -n "min-height" -n css/style.css`


------
https://chatgpt.com/codex/tasks/task_e_6842f55b5a488321a0fe2fc4cdd27e15