### PR TITLE
Add dedicated wedding video pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,27 +24,27 @@
       <h2>Weddings</h2>
 
   <div class="photo-grid">
-    <a href="index.html" class="photo-card">
+    <a href="wedding1.html" class="photo-card">
       <img src="assets/Wedding1.gif" alt="Wedding 1" />
       <span class="photo-title">LJ & Landry</span>
     </a>
-    <a href="index.html" class="photo-card">
+    <a href="wedding2.html" class="photo-card">
       <img src="assets/Wedding2.gif" alt="Wedding 2" />
       <span class="photo-title">Bryan & Emily</span>
     </a>
-    <a href="index.html" class="photo-card">
+    <a href="wedding3.html" class="photo-card">
       <img src="assets/Wedding3.gif" alt="Wedding 3" />
       <span class="photo-title">Ashlyn & Andy</span>
     </a>
-    <a href="index.html" class="photo-card">
+    <a href="wedding4.html" class="photo-card">
       <img src="assets/Wedding4.gif" alt="Wedding 4" />
       <span class="photo-title">Will & Kyoko</span>
     </a>
-    <a href="index.html" class="photo-card">
+    <a href="wedding5.html" class="photo-card">
       <img src="assets/Wedding5.gif" alt="Wedding 5" />
       <span class="photo-title">Tad & Syd</span>
     </a>
-    <a href="index.html" class="photo-card">
+    <a href="wedding6.html" class="photo-card">
       <img src="assets/Wedding6.gif" alt="Wedding 6" />
       <span class="photo-title">Sammi & Bebo</span>
     </a>

--- a/wedding2.html
+++ b/wedding2.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Wedding 2 | Samuel Perry Lee Media</title>
+  <title>Bryan & Emily | Samuel Perry Lee Media</title>
   <link rel="stylesheet" href="css/style.css" />
 </head>
 <body>
@@ -20,10 +20,11 @@
 
   <main class="video-page">
     <section>
-      <h2 class="video-title">Lexi Jo & Landry</h2>
-      <div class="video-wrapper">
-        <iframe src="https://player.vimeo.com/video/76979871" frameborder="0" allowfullscreen></iframe>
+      <h2 class="video-title">Bryan and Emily Wedding Film</h2>
+      <div style="padding:56.25% 0 0 0;position:relative;">
+        <iframe src="https://player.vimeo.com/video/1106224837?h=906ca8b546&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479&amp;autoplay=1" frameborder="0" allow="autoplay; fullscreen; picture-in-picture; clipboard-write; encrypted-media; web-share" referrerpolicy="strict-origin-when-cross-origin" style="position:absolute;top:0;left:0;width:100%;height:100%;" title="Bryan and Emily Wedding Highlight Film"></iframe>
       </div>
+      <script src="https://player.vimeo.com/api/player.js"></script>
     </section>
   </main>
   <footer>

--- a/wedding3.html
+++ b/wedding3.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>LJ & Landry | Samuel Perry Lee Media</title>
+  <title>Ashlyn & Andy | Samuel Perry Lee Media</title>
   <link rel="stylesheet" href="css/style.css" />
 </head>
 <body>
@@ -20,9 +20,9 @@
 
   <main class="video-page">
     <section>
-      <h2 class="video-title">LJ and Landry Engagement</h2>
-      <div style="padding:75% 0 0 0;position:relative;">
-        <iframe src="https://player.vimeo.com/video/1106217101?h=fa5b71e2cb&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479&amp;autoplay=1" frameborder="0" allow="autoplay; fullscreen; picture-in-picture; clipboard-write; encrypted-media; web-share" referrerpolicy="strict-origin-when-cross-origin" style="position:absolute;top:0;left:0;width:100%;height:100%;" title="LJ and Landry Engagement"></iframe>
+      <h2 class="video-title">Ashlyn and Andy</h2>
+      <div style="padding:56.25% 0 0 0;position:relative;">
+        <iframe src="https://player.vimeo.com/video/1106239979?h=f1d550c1cd&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479&amp;autoplay=1" frameborder="0" allow="autoplay; fullscreen; picture-in-picture; clipboard-write; encrypted-media; web-share" referrerpolicy="strict-origin-when-cross-origin" style="position:absolute;top:0;left:0;width:100%;height:100%;" title="Ashlyn and Andy"></iframe>
       </div>
       <script src="https://player.vimeo.com/api/player.js"></script>
     </section>

--- a/wedding4.html
+++ b/wedding4.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>LJ & Landry | Samuel Perry Lee Media</title>
+  <title>Will & Kyoko | Samuel Perry Lee Media</title>
   <link rel="stylesheet" href="css/style.css" />
 </head>
 <body>
@@ -20,9 +20,9 @@
 
   <main class="video-page">
     <section>
-      <h2 class="video-title">LJ and Landry Engagement</h2>
-      <div style="padding:75% 0 0 0;position:relative;">
-        <iframe src="https://player.vimeo.com/video/1106217101?h=fa5b71e2cb&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479&amp;autoplay=1" frameborder="0" allow="autoplay; fullscreen; picture-in-picture; clipboard-write; encrypted-media; web-share" referrerpolicy="strict-origin-when-cross-origin" style="position:absolute;top:0;left:0;width:100%;height:100%;" title="LJ and Landry Engagement"></iframe>
+      <h2 class="video-title">Will and Kyoko</h2>
+      <div style="padding:56.25% 0 0 0;position:relative;">
+        <iframe src="https://player.vimeo.com/video/1106241899?h=9d5b3eaae0&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479&amp;autoplay=1" frameborder="0" allow="autoplay; fullscreen; picture-in-picture; clipboard-write; encrypted-media; web-share" referrerpolicy="strict-origin-when-cross-origin" style="position:absolute;top:0;left:0;width:100%;height:100%;" title="Will and Kyoko"></iframe>
       </div>
       <script src="https://player.vimeo.com/api/player.js"></script>
     </section>

--- a/wedding5.html
+++ b/wedding5.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>LJ & Landry | Samuel Perry Lee Media</title>
+  <title>Tad & Syd | Samuel Perry Lee Media</title>
   <link rel="stylesheet" href="css/style.css" />
 </head>
 <body>
@@ -20,9 +20,9 @@
 
   <main class="video-page">
     <section>
-      <h2 class="video-title">LJ and Landry Engagement</h2>
-      <div style="padding:75% 0 0 0;position:relative;">
-        <iframe src="https://player.vimeo.com/video/1106217101?h=fa5b71e2cb&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479&amp;autoplay=1" frameborder="0" allow="autoplay; fullscreen; picture-in-picture; clipboard-write; encrypted-media; web-share" referrerpolicy="strict-origin-when-cross-origin" style="position:absolute;top:0;left:0;width:100%;height:100%;" title="LJ and Landry Engagement"></iframe>
+      <h2 class="video-title">Tad and Syd</h2>
+      <div style="padding:56.25% 0 0 0;position:relative;">
+        <iframe src="https://player.vimeo.com/video/1106221119?h=072ce785e9&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479&amp;autoplay=1" frameborder="0" allow="autoplay; fullscreen; picture-in-picture; clipboard-write; encrypted-media; web-share" referrerpolicy="strict-origin-when-cross-origin" style="position:absolute;top:0;left:0;width:100%;height:100%;" title="Tad and Syd Wedding"></iframe>
       </div>
       <script src="https://player.vimeo.com/api/player.js"></script>
     </section>

--- a/wedding6.html
+++ b/wedding6.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>LJ & Landry | Samuel Perry Lee Media</title>
+  <title>Sammi & Bebo | Samuel Perry Lee Media</title>
   <link rel="stylesheet" href="css/style.css" />
 </head>
 <body>
@@ -20,9 +20,9 @@
 
   <main class="video-page">
     <section>
-      <h2 class="video-title">LJ and Landry Engagement</h2>
-      <div style="padding:75% 0 0 0;position:relative;">
-        <iframe src="https://player.vimeo.com/video/1106217101?h=fa5b71e2cb&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479&amp;autoplay=1" frameborder="0" allow="autoplay; fullscreen; picture-in-picture; clipboard-write; encrypted-media; web-share" referrerpolicy="strict-origin-when-cross-origin" style="position:absolute;top:0;left:0;width:100%;height:100%;" title="LJ and Landry Engagement"></iframe>
+      <h2 class="video-title">Sammi and Bebo</h2>
+      <div style="padding:56.25% 0 0 0;position:relative;">
+        <iframe src="https://player.vimeo.com/video/1106231548?h=f2441683db&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479&amp;autoplay=1" frameborder="0" allow="autoplay; fullscreen; picture-in-picture; clipboard-write; encrypted-media; web-share" referrerpolicy="strict-origin-when-cross-origin" style="position:absolute;top:0;left:0;width:100%;height:100%;" title="Sammi and Bebo"></iframe>
       </div>
       <script src="https://player.vimeo.com/api/player.js"></script>
     </section>


### PR DESCRIPTION
## Summary
- link each wedding card on the index page to its own page
- embed the provided Vimeo videos for every wedding
- create four new wedding pages and update existing two

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688c1d97aa388321b85f321f3aea1773